### PR TITLE
fixes rails deprecation warning about :to in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 OpenStax::Accounts::Engine.routes.draw do
 
   # Redirect here if we don't know what to do (theoretically should not happen)
-  root controller: 'sessions', action: 'new'
+  root :to => 'sessions#new'
 
   # Shortcut to OmniAuth route that redirects to the Accounts server
   # This is provided by OmniAuth and is not in the SessionsController


### PR DESCRIPTION
@Dantemss this makes the error go away (one of several gems), but I didn't test that it still does what it is supposed to do.
