### PR TITLE
Enable loading dev stub authentication from iframe

### DIFF
--- a/app/controllers/openstax/accounts/dev/accounts_controller.rb
+++ b/app/controllers/openstax/accounts/dev/accounts_controller.rb
@@ -2,6 +2,8 @@ module OpenStax
   module Accounts
     module Dev
       class AccountsController < OpenStax::Accounts::Dev::BaseController
+        # Allow accessing from inside an iframe
+        before_filter :allow_iframe_access, only: [:index, :search]
 
         def index
         end
@@ -19,6 +21,12 @@ module OpenStax
           @account = Account.find_by(openstax_uid: params[:id])
           sign_in(@account)
           redirect_back key: :accounts_return_to, strategies: [:session]
+        end
+
+        private
+
+        def allow_iframe_access
+          response.headers.except! 'X-Frame-Options'
         end
 
       end

--- a/spec/controllers/openstax/accounts/dev/accounts_controller_spec.rb
+++ b/spec/controllers/openstax/accounts/dev/accounts_controller_spec.rb
@@ -16,6 +16,12 @@ module OpenStax::Accounts
         expect(controller.current_account).to eq(account)
         expect(controller.current_account.is_anonymous?).to eq(false)
       end
+
+      it 'should not set X-Frame-Options header' do
+        get :index
+        expect(response.header['X-Frame-Options']).to be_nil
+      end
+
     end
   end
 end


### PR DESCRIPTION
This is needed for the concept coach login so FE dev's don't have to run accounts for testing logins.