### PR TITLE
Let login redirect to approved external URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ signed in user (`current_user` and `current_user=` methods).  If you choose to
 create your own custom user object, you can teach this gem how to translate
 between a user object and an account object.
 
-To do this, you need to set a `account_user_mapper` in this configuration.  
+To do this, you need to set a `account_user_mapper` in this configuration.
 
     config.account_user_mapper = MyAccountUserMapper
 
@@ -97,10 +97,10 @@ The account_user_mapper is a class that provides two class methods:
       # If no user exists for this account, one should
       # be created.
     end
-  
+
     def self.user_to_account(user)
       # Converts the given user to an account.
-    end 
+    end
 
 Accounts are never nil. When a user is signed out, the current account is the
 AnonymousAccount (responding true to `is_anonymous?`). You can follow the same
@@ -110,6 +110,20 @@ translations.
 
 The default `account_user_mapper` assumes the account object and
 the user object are the same in your application.
+
+Applications can accept a custom redirect URL on their login route provided by this
+gem.  This is useful when external apps need to authenticate against the application
+but return the user to a URL outside of the application.  To achieve this, the
+external app would redirect their users to the login route with a `return_to` parameter
+appended, e.g. `.../accounts/login?return_to=http://othersite.com`.  The application
+hosting accounts-rails must provide a proc to approve these `return_to` URLs:
+
+    config.return_to_url_approver = ->(url) {
+      url == "http://othersite.com"
+    }
+
+This approver proc should returns true iff the incoming URL is approved.
+
 
 Syncing with Accounts
 ---------------------
@@ -153,8 +167,8 @@ Example Application
 There is an example application included in the gem in the `example` folder.
 Here are the steps to follow:
 
-1. Download (clone) the OpenStax Accounts site from github.com/openstax/accounts.  
-1. In the site's `config` folder put a `secret_settings.yml` file that has values for the 
+1. Download (clone) the OpenStax Accounts site from github.com/openstax/accounts.
+1. In the site's `config` folder put a `secret_settings.yml` file that has values for the
 following keys: `facebook_app_id`, `facebook_app_secret`, `twitter_consumer_key`, `twitter_consumer_secret`.  If you don't have access to these values, you can always make dummy apps on facebook and twitter.
 2. Do the normal steps to get this site online:
     1. Run `bundle install --without production`
@@ -163,14 +177,14 @@ following keys: `facebook_app_id`, `facebook_app_secret`, `twitter_consumer_key`
 2. Open this accounts site in a web browser (defaults to http://localhost:2999)
 3. Navigate to http://localhost:2999/oauth/applications
 4. Click `New application`
-    5. Set the callback URL to `http://localhost:4000/accounts/auth/openstax/callback`.  
+    5. Set the callback URL to `http://localhost:4000/accounts/auth/openstax/callback`.
 Port 4000 is where you'll be running the example application.
     1. The name can be whatever.
     2. Click the `Trusted?` checkbox.
     3. Click `Submit`.
     4. Keep this window open so you can copy the application ID and secret into the example app
 5. Leave the accounts app running
-6. Download (clone) the OpenStax Accounts gem from github.com/openstax/accounts-rails. 
+6. Download (clone) the OpenStax Accounts gem from github.com/openstax/accounts-rails.
 The example application is in the `example` folder.
 In that folder's config folder, create a `secret_settings.yml` file according to the
 instructions in `secret_settings.yml.example`. Run the example server in the normal way (bundle install..., migrate db, rails server).

--- a/app/controllers/openstax/accounts/sessions_controller.rb
+++ b/app/controllers/openstax/accounts/sessions_controller.rb
@@ -6,6 +6,9 @@ module OpenStax
         if configuration.enable_stubbing?
           redirect_to dev_accounts_path
         else
+          if configuration.is_return_to_url_approved?(params[:return_to])
+            store_url url: params[:return_to], key: :accounts_return_to, strategies: [:session]
+          end
           store_fallback key: :accounts_return_to, strategies: [:session]
           redirect_to openstax_login_path
         end

--- a/lib/openstax/accounts/configuration.rb
+++ b/lib/openstax/accounts/configuration.rb
@@ -71,6 +71,14 @@ module OpenStax
         URI.join(openstax_accounts_url, "logout").to_s
       end
 
+      attr_writer :return_to_url_approver
+
+      def is_return_to_url_approved?(return_to_url)
+        return_to_url &&
+        @return_to_url_approver.is_a?(Proc) &&
+        @return_to_url_approver.call(return_to_url)
+      end
+
       def initialize
         @openstax_application_id = 'SET ME!'
         @openstax_application_secret = 'SET ME!'
@@ -85,6 +93,7 @@ module OpenStax
         @min_search_characters = 3
         @max_search_items = 10
         @logout_redirect_url = nil
+        @return_to_url_approver = nil
         super
       end
 

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = "6.2.0"
+    VERSION = "6.3.0"
   end
 end

--- a/spec/lib/openstax/accounts/configuration_spec.rb
+++ b/spec/lib/openstax/accounts/configuration_spec.rb
@@ -24,6 +24,16 @@ module OpenStax
         expect(config.logout_redirect_url(a_fake_request)).to eq "howdy"
       end
 
+      it "says return_to urls not approved when nil" do
+        config.return_to_url_approver = ->(url) { true }
+        expect(config.is_return_to_url_approved?(nil)).to be_falsy
+      end
+
+      it "says return_to urls not approved when approver nil" do
+        config.return_to_url_approver = nil
+        expect(config.is_return_to_url_approved?("http://www.google.com")).to be_falsy
+      end
+
     end
   end
 end


### PR DESCRIPTION
Extends the login route with a `return_to` URL parameter, e.g. `/accounts/login?return_to=blah`, and redirects users to that URL provided that it passes an application-specific test.  To approve `return_to` URLs, applications must set a Proc in this gem's config, e.g.

```ruby
config.return_to_url_approver = ->(url) {
  url == "http://othersite.com"
}
```

