### PR TITLE
Fix/invalid format redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,8 @@ gem "jquery-rails"
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+
+group :development, :test do
+  # To use debugger
+  gem 'byebug'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,3 @@ gem "jquery-rails"
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
-
-# To use debugger
-gem 'byebug'

--- a/lib/openstax/accounts/action_controller/base.rb
+++ b/lib/openstax/accounts/action_controller/base.rb
@@ -47,8 +47,8 @@ module OpenStax
           store_url key: :accounts_return_to, strategies: [:session]
 
           respond_to do |format|
-            format.html { redirect_to openstax_accounts.login_url }
             format.json { head(:forbidden) }
+            format.any  { redirect_to openstax_accounts.login_url }
           end
         end
 

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = "6.3.0"
+    VERSION = "6.3.1"
   end
 end

--- a/spec/controllers/openstax/accounts/uses_this_engine_controller_spec.rb
+++ b/spec/controllers/openstax/accounts/uses_this_engine_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe "Controllers that use this engine", type: :controller do
+
+  controller do
+    before_filter :authenticate_user!
+    def action_needing_authentication; end
+  end
+
+  it 'should not freak out for what rails thinks are weird formats' do
+    # When accounts-rails intercepts a request to authenticate a user and that request
+    # has what Rails sees as a weird format, e.g.:
+    #   https://example.org/qa/271/section/4.6
+    # it was freaking out.  This spec makes sure it handles that kind of request URL
+
+    routes.draw { get "action_needing_authentication" => "anonymous#action_needing_authentication" }
+
+    expect{
+      get :action_needing_authentication, format: :'6'
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Tutor needs to deal with format-less urls like `/qa/94/section/7.1`

Rails parses that to mean format `1` which isn't matched by a responder block.  It then raises an `ActionController::UnknownFormat` exception

Since it's impossible to guess all possible url endings, match and redirect `.any`

I'm having trouble writing a spec for this, I tried adding it to the sessions_controller_spec, but that doesn't seem to include base, or at least doesn't call `authenticate_user!`