### PR TITLE
Fixes the group creation

### DIFF
--- a/accounts-rails.gemspec
+++ b/accounts-rails.gemspec
@@ -38,5 +38,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "responders"
   s.add_development_dependency "webmock", ">=2.0.1"
   s.add_development_dependency "vcr"
-  s.add_development_dependency "byebug"
 end

--- a/app/routines/openstax/accounts/create_group.rb
+++ b/app/routines/openstax/accounts/create_group.rb
@@ -9,11 +9,11 @@ module OpenStax
       def exec(owner:, name: nil, is_public: false)
         group = OpenStax::Accounts::Group.new(name: name, is_public: is_public)
         group.requestor = owner
-        group.add_member(owner)
-        group.add_owner(owner)
 
-        group.openstax_uid = -SecureRandom.hex(4).to_i(16)/2 \
-          if OpenStax::Accounts.configuration.enable_stubbing? || !owner.has_authenticated?
+        if OpenStax::Accounts.configuration.enable_stubbing? || !owner.has_authenticated?
+          group.openstax_uid = -SecureRandom.hex(4).to_i(16)/2
+          group.add_owner(owner)
+        end
 
         group.save
 

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = "6.3.2"
+    VERSION = "6.4.0"
   end
 end

--- a/spec/routines/openstax/accounts/create_group_spec.rb
+++ b/spec/routines/openstax/accounts/create_group_spec.rb
@@ -19,7 +19,7 @@ module OpenStax
         expect(group.name).to eq 'Test'
         expect(group.is_public).to eq true
         expect(group.owners.first).to eq owner
-        expect(group.members.first).to eq owner
+        expect(group.members).to be_empty
       end
 
       after(:all) do


### PR DESCRIPTION
Accounts now automatically adds the requesting user as a group owner, which was making group creation fail. This PR fixes that.