### PR TITLE
allow signup param to pass through to accounts

### DIFF
--- a/app/controllers/openstax/accounts/sessions_controller.rb
+++ b/app/controllers/openstax/accounts/sessions_controller.rb
@@ -10,7 +10,10 @@ module OpenStax
             store_url url: params[:return_to], key: :accounts_return_to, strategies: [:session]
           end
           store_fallback key: :accounts_return_to, strategies: [:session]
-          redirect_to openstax_login_path
+
+          forwardable_params =
+            params.slice(*configuration.forwardable_login_param_keys.map(&:to_s))
+          redirect_to openstax_login_path(forwardable_params)
         end
       end
 

--- a/lib/openstax/accounts/action_controller/base.rb
+++ b/lib/openstax/accounts/action_controller/base.rb
@@ -4,7 +4,7 @@ module OpenStax
       module Base
 
         def self.included(base)
-          base.helper_method :current_user, :signed_in?
+          base.helper_method :current_user, :signed_in?, :openstax_accounts_login_path
         end
 
         # Returns the current user
@@ -39,6 +39,14 @@ module OpenStax
             OpenStax::Accounts::CurrentUserManager.new(request, session, cookies)
         end
 
+        def login_params
+          @login_params ||= {}
+        end
+
+        def openstax_accounts_login_path
+          openstax_accounts.login_path(login_params)
+        end
+
         def authenticate_user!
           account = current_account
 
@@ -48,7 +56,9 @@ module OpenStax
 
           respond_to do |format|
             format.json { head(:forbidden) }
-            format.any  { redirect_to openstax_accounts.login_url }
+            format.any  {
+              redirect_to openstax_accounts_login_path
+            }
           end
         end
 

--- a/lib/openstax/accounts/configuration.rb
+++ b/lib/openstax/accounts/configuration.rb
@@ -98,7 +98,7 @@ module OpenStax
         @max_search_items = 10
         @logout_redirect_url = nil
         @return_to_url_approver = nil
-        @forwardable_login_param_keys = [:signup_at]
+        @forwardable_login_param_keys = [:signup_at, :go]
         super
       end
 

--- a/lib/openstax/accounts/configuration.rb
+++ b/lib/openstax/accounts/configuration.rb
@@ -60,6 +60,10 @@ module OpenStax
       # to the default Accounts logout URL.
       attr_writer :logout_redirect_url
 
+      # forwardable_login_param_keys
+      # Which params are forwarded on the accounts login path
+      attr_accessor :forwardable_login_param_keys
+
       def logout_redirect_url(request)
         (@logout_redirect_url.is_a?(Proc) ?
            @logout_redirect_url.call(request) :
@@ -94,6 +98,7 @@ module OpenStax
         @max_search_items = 10
         @logout_redirect_url = nil
         @return_to_url_approver = nil
+        @forwardable_login_param_keys = [:signup_at]
         super
       end
 

--- a/lib/openstax/accounts/engine.rb
+++ b/lib/openstax/accounts/engine.rb
@@ -19,7 +19,7 @@ module OpenStax
   module Accounts
     class Engine < ::Rails::Engine
       isolate_namespace OpenStax::Accounts
-      
+
       initializer "openstax_accounts.factories",
         :after => "factory_girl.set_factory_paths" do
         FactoryGirl.definition_file_paths << File.join(root, 'spec', 'factories') if defined?(FactoryGirl)
@@ -33,13 +33,16 @@ module OpenStax
       end
 
       SETUP_PROC = lambda do |env|
+        # Useful link for how to pass params through omniauth/doorkeeper:
+        #  https://github.com/doorkeeper-gem/doorkeeper/wiki/Passing-parameters-from-a-devise-client-to-doorkeeper-(like-locale)
+        env['omniauth.strategy'].options.authorize_params = env["rack.request.query_hash"]
         env['omniauth.strategy'].options[:client_options][:site] = OpenStax::Accounts.configuration.openstax_accounts_url
       end
 
       # Doesn't work to put this omniauth code in an engine initializer, instead:
       # https://gist.github.com/pablomarti/5243118
       middleware.use ::OmniAuth::Builder do
-        provider :openstax, 
+        provider :openstax,
                  OpenStax::Accounts.configuration.openstax_application_id,
                  OpenStax::Accounts.configuration.openstax_application_secret,
                  :setup => SETUP_PROC

--- a/spec/controllers/openstax/accounts/forwards_params_spec.rb
+++ b/spec/controllers/openstax/accounts/forwards_params_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe "Forwards params", type: :request do
+
+  class ForwardsParamsController < OpenStax::Accounts::ApplicationController
+    before_filter :set_login_param
+    before_filter :authenticate_user!
+
+    def action_needing_authentication; end
+
+    def set_login_param
+      login_params[:signup_at] = "foo"
+      login_params[:go] = "bar"
+    end
+  end
+
+  before(:all) do
+    Rails.application.routes.send(:eval_block, Proc.new do
+      get '/forwards_params_route' => 'forwards_params#action_needing_authentication'
+    end)
+  end
+
+  it 'should forward signup_at' do
+    test_forwards(key: :signup_at, value: "foo")
+  end
+
+  it "should forward go" do
+    test_forwards(key: :go, value: "bar")
+  end
+
+  def test_forwards(key:, value:)
+    get '/forwards_params_route'
+
+    expect(redirect_path).to eq "/accounts/login"
+    expect(redirect_query_hash).to include(key => value)
+
+    with_stubbing(false) do
+      get redirect_path_and_query
+    end
+
+    expect(redirect_path).to eq "/accounts/auth/openstax"
+    expect(redirect_query_hash).to include(key => value)
+
+    get redirect_path_and_query
+
+    expect(redirect_path).to eq("/oauth/authorize")
+    expect(redirect_query_hash).to include(key => value)
+
+    # This last redirect was to Accounts, so we don't follow it
+  end
+
+  def redirect_path
+    redirect_uri.path
+  end
+
+  def redirect_path_and_query
+    "#{redirect_uri.path}?#{redirect_uri.query}"
+  end
+
+  def redirect_query_hash
+    Rack::Utils.parse_nested_query(redirect_uri.query).symbolize_keys
+  end
+
+  def redirect_uri
+    expect(response.code).to eq "302"
+    uri = URI.parse(response.headers["Location"])
+  end
+end


### PR DESCRIPTION
When a product site (e.g Tutor) passes a `signup` parameter when redirecting someone to log in, this PR will forward that parameter on to Accounts' doorkeeper authorize route.  There the `authenticate_user!` filter will send the user to the login page and forward this parameter along.  