### PR TITLE
Sync role and UUID

### DIFF
--- a/app/models/openstax/accounts/account.rb
+++ b/app/models/openstax/accounts/account.rb
@@ -27,7 +27,6 @@ module OpenStax::Accounts
     validates :faculty_status, presence: true
 
     enum role: [:unknown_role, :student, :instructor, :administrator, :librarian, :designer, :other]
-    after_initialize :set_default_role
     validates :role, presence: true
 
     validates :openstax_uid, uniqueness: { allow_nil: true }
@@ -59,10 +58,6 @@ module OpenStax::Accounts
 
     def set_default_faculty_status
       self.faculty_status ||= :no_faculty_info
-    end
-
-    def set_default_role
-      self.role ||= :unknown_role
     end
 
     def syncing_or_stubbing?

--- a/app/models/openstax/accounts/account.rb
+++ b/app/models/openstax/accounts/account.rb
@@ -24,8 +24,11 @@ module OpenStax::Accounts
                           :confirmed_faculty, :rejected_faculty]
 
     after_initialize :set_default_faculty_status
-
     validates :faculty_status, presence: true
+
+    enum role: [:unknown_role, :student, :instructor, :administrator, :librarian, :designer, :other]
+    after_initialize :set_default_role
+    validates :role, presence: true
 
     validates :openstax_uid, uniqueness: { allow_nil: true }
     validates :username, uniqueness: { allow_nil: true }
@@ -56,6 +59,10 @@ module OpenStax::Accounts
 
     def set_default_faculty_status
       self.faculty_status ||= :no_faculty_info
+    end
+
+    def set_default_role
+      self.role ||= :unknown_role
     end
 
     def syncing_or_stubbing?

--- a/app/representers/openstax/accounts/api/v1/account_representer.rb
+++ b/app/representers/openstax/accounts/api/v1/account_representer.rb
@@ -68,6 +68,22 @@ module OpenStax
                      }"
                    }
 
+          property :role,
+                   as: :self_reported_role,
+                   type: String,
+                   schema_info: {
+                      description: "The user's uncorroborated role, one of [#{
+                        OpenStax::Accounts::Account.roles.keys.map(&:to_s).join(', ')
+                      }]",
+                      required: true
+                   }
+
+          property :uuid,
+                   type: String,
+                   schema_info: {
+                     description: "The UUID as set by Accounts"
+                   }
+
         end
       end
     end

--- a/app/routines/openstax/accounts/find_or_create_account.rb
+++ b/app/routines/openstax/accounts/find_or_create_account.rb
@@ -8,7 +8,7 @@ module OpenStax
 
       def exec(email: nil, username: nil, password: nil,
                first_name: nil, last_name: nil, full_name: nil, title: nil,
-               salesforce_contact_id: nil, faculty_status: nil)
+               salesforce_contact_id: nil, faculty_status: nil, role: nil)
         raise ArgumentError,
               'You must specify either an email address or a username (and an optional password)' \
                 if email.nil? && username.nil?
@@ -21,7 +21,8 @@ module OpenStax
           response = Api.find_or_create_account(
             email: email, username: username, password: password,
             first_name: first_name, last_name: last_name, full_name: full_name,
-            salesforce_contact_id: salesforce_contact_id, faculty_status: faculty_status)
+            salesforce_contact_id: salesforce_contact_id, faculty_status: faculty_status,
+            role: role)
           fatal_error(code: :invalid_inputs) unless (200..202).include?(response.status)
 
           struct = OpenStruct.new

--- a/app/routines/openstax/accounts/sync_accounts.rb
+++ b/app/routines/openstax/accounts/sync_accounts.rb
@@ -8,7 +8,7 @@ module OpenStax
     class SyncAccounts
 
       SYNC_ATTRIBUTES = ['username', 'first_name', 'last_name', 'full_name', 'title',
-                         'faculty_status', 'salesforce_contact_id']
+                         'faculty_status', 'salesforce_contact_id', 'uuid', 'role']
 
       lev_routine transaction: :no_transaction
 

--- a/db/migrate/9_add_uuid_and_role_to_accounts_accounts.rb
+++ b/db/migrate/9_add_uuid_and_role_to_accounts_accounts.rb
@@ -1,0 +1,9 @@
+class AddUuidAndRoleToAccountsAccounts < ActiveRecord::Migration
+  def change
+    add_column :openstax_accounts_accounts, :uuid, :string
+    add_index :openstax_accounts_accounts, :uuid, unique: true
+
+    add_column :openstax_accounts_accounts, :role, :integer, default: 0, null: false
+    add_index :openstax_accounts_accounts, :role
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 1001) do
     t.datetime "updated_at",                        null: false
     t.integer  "faculty_status",        default: 0, null: false
     t.string   "salesforce_contact_id"
+    t.string   "uuid"
+    t.integer  "role",                  default: 0, null: false
   end
 
   add_index "openstax_accounts_accounts", ["access_token"], name: "index_openstax_accounts_accounts_on_access_token", unique: true
@@ -33,8 +35,10 @@ ActiveRecord::Schema.define(version: 1001) do
   add_index "openstax_accounts_accounts", ["full_name"], name: "index_openstax_accounts_accounts_on_full_name"
   add_index "openstax_accounts_accounts", ["last_name"], name: "index_openstax_accounts_accounts_on_last_name"
   add_index "openstax_accounts_accounts", ["openstax_uid"], name: "index_openstax_accounts_accounts_on_openstax_uid", unique: true
+  add_index "openstax_accounts_accounts", ["role"], name: "index_openstax_accounts_accounts_on_role"
   add_index "openstax_accounts_accounts", ["salesforce_contact_id"], name: "index_openstax_accounts_accounts_on_salesforce_contact_id"
   add_index "openstax_accounts_accounts", ["username"], name: "index_openstax_accounts_accounts_on_username", unique: true
+  add_index "openstax_accounts_accounts", ["uuid"], name: "index_openstax_accounts_accounts_on_uuid", unique: true
 
   create_table "openstax_accounts_group_members", force: :cascade do |t|
     t.integer  "group_id",   null: false

--- a/spec/factories/openstax_accounts_account.rb
+++ b/spec/factories/openstax_accounts_account.rb
@@ -4,5 +4,7 @@ FactoryGirl.define do
     username     { SecureRandom.hex.to_s }
     access_token { SecureRandom.hex.to_s }
     faculty_status { OpenStax::Accounts::Account.faculty_statuses[:no_faculty_info] }
+    role         { OpenStax::Accounts::Account.roles[:unknown_role] }
+    uuid         { SecureRandom.uuid }
   end
 end

--- a/spec/models/openstax/accounts/account_spec.rb
+++ b/spec/models/openstax/accounts/account_spec.rb
@@ -34,6 +34,12 @@ module OpenStax::Accounts
           FactoryGirl.create(:openstax_accounts_account, username: nil)
         }.not_to raise_error
       end
+
+      it 'requires a role' do
+        expect{
+          FactoryGirl.create(:openstax_accounts_account, role: nil)
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
 
     context 'updates' do

--- a/spec/routines/openstax/accounts/find_or_create_account_spec.rb
+++ b/spec/routines/openstax/accounts/find_or_create_account_spec.rb
@@ -36,7 +36,8 @@ module OpenStax
         expect(OpenStax::Accounts::Api).to receive(:find_or_create_account).with(
           email: 'bob@example.com', username: nil, password: nil,
           first_name: 'Bob', last_name: 'Smith', full_name: 'Bob Smith',
-          salesforce_contact_id: 'b0b', faculty_status: :rejected_faculty
+          salesforce_contact_id: 'b0b', faculty_status: :rejected_faculty,
+          role: :instructor
         ).and_return(find_or_create_account_response)
 
         FindOrCreateAccount.call(
@@ -45,7 +46,8 @@ module OpenStax
           last_name: 'Smith',
           full_name: 'Bob Smith',
           salesforce_contact_id: 'b0b',
-          faculty_status: :rejected_faculty
+          faculty_status: :rejected_faculty,
+          role: :instructor
         )
       end
 

--- a/spec/routines/openstax/accounts/sync_accounts_spec.rb
+++ b/spec/routines/openstax/accounts/sync_accounts_spec.rb
@@ -10,7 +10,7 @@ module OpenStax
         allow_any_instance_of(controller_class).to(
           receive(:updates) do |controller|
             controller.render :json => [{id: 1, application_id: 1,
-                                        user: {id: 2, username: 'user'},
+                                        user: {id: 2, username: 'user', self_reported_role: 'instructor', uuid: 'booyah'},
                                         unread_updates: 1, default_contact_info_id: 1},
                                         {id: 3, application_id: 1,
                                         user: {id: 4, username: 'fuego'},
@@ -36,6 +36,8 @@ module OpenStax
           expect(Account.count).to eq 2
           expect(Account.first.openstax_uid).to eq 2
           expect(Account.first.username).to eq 'user'
+          expect(Account.first.role).to eq 'instructor'
+          expect(Account.first.uuid).to eq 'booyah'
           expect(Account.last.openstax_uid).to eq 4
           expect(Account.last.username).to eq 'fuego'
 


### PR DESCRIPTION
self-reported role and UUID have existed in Accounts for a while, this PR brings these over locally to apps that use this engine.  The fields are now stored in the `Account` record and are sync'd during the existing syncing operation.