### PR TITLE
use a configurable parameter to limit num of users per update sync call

### DIFF
--- a/lib/openstax/accounts/api.rb
+++ b/lib/openstax/accounts/api.rb
@@ -74,12 +74,14 @@ module OpenStax
 
       # Retrieves information about accounts that have been
       # recently updated.
-      # Results are limited to accounts that have used the current app.
+      # Results are limited to accounts that have used the current app, and
+      # limited in quantity per call by a configuration parameter.
       # Takes an options hash.
       # On failure, throws an Exception, just like the request method.
       # On success, returns an OAuth2::Response object.
       def self.get_application_account_updates(options = {})
-        request(:get, 'application_users/updates', options)
+        limit = OpenStax::Accounts.configuration.max_user_updates_per_request
+        request(:get, "application_users/updates#{ '?limit=' + limit.to_s if !limit.blank? }", options)
       end
 
       # Marks account updates as "read".

--- a/lib/openstax/accounts/configuration.rb
+++ b/lib/openstax/accounts/configuration.rb
@@ -64,6 +64,13 @@ module OpenStax
       # Which params are forwarded on the accounts login path
       attr_accessor :forwardable_login_param_keys
 
+      # max_user_updates_per_request
+      # When the user profile sync operation is called, this parameter will limit
+      # the number of returned profile updates from Accounts; helpful when all
+      # accounts have been marked as updated on Accounts so that we don't get
+      # overloaded.
+      attr_accessor :max_user_updates_per_request
+
       def logout_redirect_url(request)
         (@logout_redirect_url.is_a?(Proc) ?
            @logout_redirect_url.call(request) :
@@ -99,6 +106,7 @@ module OpenStax
         @logout_redirect_url = nil
         @return_to_url_approver = nil
         @forwardable_login_param_keys = [:signup_at, :go]
+        @max_user_updates_per_request = 250
         super
       end
 

--- a/spec/lib/openstax/accounts/api_spec.rb
+++ b/spec/lib/openstax/accounts/api_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module OpenStax
   module Accounts
     describe Api do
@@ -6,29 +8,30 @@ module OpenStax
                          first_name: 'Some', last_name: 'User', full_name: 'SomeUser',
                          title: 'Sir', openstax_uid: 1, access_token: 'secret') }
 
+      def reset(controller)
+        controller.last_action = nil
+        controller.last_json = nil
+        controller.last_params = nil
+      end
+
       it 'makes api requests' do
-        expect(::Api::DummyController.last_action).to be_nil
-        expect(::Api::DummyController.last_params).to be_nil
+        reset(::Api::DummyController)
         Api.request(:post, 'dummy', :params => {:test => true})
         expect(::Api::DummyController.last_action).to eq :dummy
         expect(::Api::DummyController.last_params).to include 'test' => 'true'
       end
 
       context 'users' do
-
+        before(:each) { reset(::Api::UsersController) }
         let!(:account) { FactoryGirl.create :openstax_accounts_account }
 
         it 'makes api call to users index' do
-          ::Api::UsersController.last_action = nil
-          ::Api::UsersController.last_params = nil
           Api.search_accounts('something')
           expect(::Api::UsersController.last_action).to eq :index
           expect(::Api::UsersController.last_params).to include :q => 'something'
         end
 
         it 'makes api call to user update' do
-          ::Api::UsersController.last_action = nil
-          ::Api::UsersController.last_json = nil
           Api.update_account(account)
           expect(::Api::UsersController.last_action).to eq :update
           expect(::Api::UsersController.last_json).to include(
@@ -37,8 +40,6 @@ module OpenStax
         end
 
         it 'makes api call to (temp) user create by email' do
-          ::Api::UsersController.last_action = nil
-          ::Api::UsersController.last_json = nil
           Api.find_or_create_account(email: 'dummy@dum.my')
           expect(::Api::UsersController.last_action).to eq :create
           expect(::Api::UsersController.last_json).to(
@@ -47,52 +48,51 @@ module OpenStax
         end
 
         it 'makes api call to (temp) user create by username' do
-          ::Api::UsersController.last_action = nil
-          ::Api::UsersController.last_json = nil
           Api.find_or_create_account(username: 'dummy')
           expect(::Api::UsersController.last_action).to eq :create
           expect(::Api::UsersController.last_json).to(
             include('username' => 'dummy')
           )
         end
-
       end
 
       context 'application_users' do
+        before(:each) { reset(::Api::ApplicationUsersController) }
 
         it 'makes api call to application_users index' do
-          ::Api::ApplicationUsersController.last_action = nil
-          ::Api::ApplicationUsersController.last_params = nil
           Api.search_application_accounts('something')
           expect(::Api::ApplicationUsersController.last_action).to eq :index
           expect(::Api::ApplicationUsersController.last_params).to include :q => 'something'
         end
 
         it 'makes api call to application_users updates' do
-          ::Api::ApplicationUsersController.last_action = nil
           Api.get_application_account_updates
           expect(::Api::ApplicationUsersController.last_action).to eq :updates
+          expect(::Api::ApplicationUsersController.last_params).to include limit: "250"
+        end
+
+        it 'does not limit updates call if param blank' do
+          allow(OpenStax::Accounts.configuration).to receive(:max_user_updates_per_request) { "" }
+          Api.get_application_account_updates
+          expect(::Api::ApplicationUsersController.last_action).to eq :updates
+          expect(::Api::ApplicationUsersController.last_params.keys).not_to include "limit"
         end
 
         it 'makes api call to application_users updated' do
-          ::Api::ApplicationUsersController.last_action = nil
-          ::Api::ApplicationUsersController.last_json = nil
           Api.mark_account_updates_as_read([{id: 1, read_updates: 1}])
           expect(::Api::ApplicationUsersController.last_action).to eq :updated
           expect(::Api::ApplicationUsersController.last_json).to include(
             {'id' => 1, 'read_updates' => 1})
         end
-
       end
 
       context 'groups' do
+        before(:each) { reset(::Api::GroupsController) }
 
         let!(:account) { FactoryGirl.create :openstax_accounts_account }
         let!(:group)   { FactoryGirl.create :openstax_accounts_group }
 
         it 'makes api call to groups create' do
-          ::Api::GroupsController.last_action = nil
-          ::Api::GroupsController.last_json = nil
           Api.create_group(account, group)
           expect(::Api::GroupsController.last_action).to eq :create
           expect(::Api::GroupsController.last_json).to include(
@@ -101,9 +101,6 @@ module OpenStax
 
         it 'makes api call to group update' do
           group.save!
-          ::Api::GroupsController.last_action = nil
-          ::Api::GroupsController.last_params = nil
-          ::Api::GroupsController.last_json = nil
           Api.update_group(account, group)
           expect(::Api::GroupsController.last_action).to eq :update
           expect(::Api::GroupsController.last_params).to include(
@@ -114,24 +111,20 @@ module OpenStax
 
         it 'makes api call to group destroy' do
           group.save!
-          ::Api::GroupsController.last_action = nil
-          ::Api::GroupsController.last_params = nil
           Api.destroy_group(account, group)
           expect(::Api::GroupsController.last_action).to eq :destroy
           expect(::Api::GroupsController.last_params).to include(
             {'id' => group.openstax_uid.to_s})
         end
-
       end
 
       context 'group_members' do
+        before(:each) { reset(::Api::GroupMembersController) }
 
         let!(:account) { FactoryGirl.create :openstax_accounts_account }
         let!(:group_member)   { FactoryGirl.build :openstax_accounts_group_member }
 
         it 'makes api call to group_members create' do
-          ::Api::GroupMembersController.last_action = nil
-          ::Api::GroupMembersController.last_params = nil
           Api.create_group_member(account, group_member)
           expect(::Api::GroupMembersController.last_action).to eq :create
           expect(::Api::GroupMembersController.last_params).to include(
@@ -141,25 +134,21 @@ module OpenStax
 
         it 'makes api call to group_member destroy' do
           group_member.save!
-          ::Api::GroupMembersController.last_action = nil
-          ::Api::GroupMembersController.last_params = nil
           Api.destroy_group_member(account, group_member)
           expect(::Api::GroupMembersController.last_action).to eq :destroy
           expect(::Api::GroupMembersController.last_params).to include(
             {'group_id' => group_member.group_id.to_s,
              'user_id' => group_member.user_id.to_s})
         end
-
       end
 
       context 'group_owners' do
+        before(:each) { reset(::Api::GroupOwnersController) }
 
         let!(:account)      { FactoryGirl.create :openstax_accounts_account }
         let!(:group_owner) { FactoryGirl.build :openstax_accounts_group_owner }
 
         it 'makes api call to group_owners create' do
-          ::Api::GroupOwnersController.last_action = nil
-          ::Api::GroupOwnersController.last_params = nil
           Api.create_group_owner(account, group_owner)
           expect(::Api::GroupOwnersController.last_action).to eq :create
           expect(::Api::GroupOwnersController.last_params).to include(
@@ -169,25 +158,21 @@ module OpenStax
 
         it 'makes api call to group_owner destroy' do
           group_owner.save!
-          ::Api::GroupOwnersController.last_action = nil
-          ::Api::GroupOwnersController.last_params = nil
           Api.destroy_group_owner(account, group_owner)
           expect(::Api::GroupOwnersController.last_action).to eq :destroy
           expect(::Api::GroupOwnersController.last_params).to include(
             {'group_id' => group_owner.group_id.to_s,
              'user_id' => group_owner.user_id.to_s})
         end
-
       end
 
       context 'group_nestings' do
+        before(:each) { reset(::Api::GroupNestingsController) }
 
         let!(:account)      { FactoryGirl.create :openstax_accounts_account }
         let!(:group_nesting) { FactoryGirl.build :openstax_accounts_group_nesting }
 
         it 'makes api call to group_nestings (create)' do
-          ::Api::GroupNestingsController.last_action = nil
-          ::Api::GroupNestingsController.last_params = nil
           Api.create_group_nesting(account, group_nesting)
           expect(::Api::GroupNestingsController.last_action).to eq :create
           expect(::Api::GroupNestingsController.last_params).to include(
@@ -197,36 +182,31 @@ module OpenStax
 
         it 'makes api call to group_nesting (destroy)' do
           group_nesting.save!
-          ::Api::GroupNestingsController.last_action = nil
-          ::Api::GroupNestingsController.last_params = nil
           Api.destroy_group_nesting(account, group_nesting)
           expect(::Api::GroupNestingsController.last_action).to eq :destroy
           expect(::Api::GroupNestingsController.last_params).to include(
             {'group_id' => group_nesting.container_group_id.to_s,
              'member_group_id' => group_nesting.member_group_id.to_s})
         end
-
       end
 
       context 'application_groups' do
+        before(:each) { reset(::Api::ApplicationGroupsController) }
 
         it 'makes api call to application_groups_updates' do
-          ::Api::ApplicationGroupsController.last_action = nil
           Api.get_application_group_updates
           expect(::Api::ApplicationGroupsController.last_action).to eq :updates
         end
 
         it 'makes api call to application_groups_updated' do
-          ::Api::ApplicationGroupsController.last_action = nil
-          ::Api::ApplicationGroupsController.last_json = nil
           Api.mark_group_updates_as_read([{id: 1, read_updates: 1}])
           expect(::Api::ApplicationGroupsController.last_action).to eq :updated
           expect(::Api::ApplicationGroupsController.last_json).to include(
             {'id' => 1, 'read_updates' => 1})
         end
-
       end
 
     end
+
   end
 end


### PR DESCRIPTION
Updates gem to use the `limit` feature when calling for application user updates on Accounts.