### PR TITLE
set uuid and role in sessions callback, update info on all logins

### DIFF
--- a/app/handlers/openstax/accounts/sessions_callback.rb
+++ b/app/handlers/openstax/accounts/sessions_callback.rb
@@ -21,7 +21,7 @@ module OpenStax
 
         # http://apidock.com/rails/v4.0.2/ActiveRecord/Relation/find_or_create_by
         begin
-          outputs[:account] = Account.find_or_create_by(openstax_uid: @auth_data.uid) do |account|
+          outputs[:account] = Account.find_or_initialize_by(openstax_uid: @auth_data.uid).tap do |account|
             account.username     = @auth_data.info.nickname
             account.first_name   = @auth_data.info.first_name
             account.last_name    = @auth_data.info.last_name
@@ -30,14 +30,26 @@ module OpenStax
             account.access_token = @auth_data.credentials.token
 
             # Gracefully handle absent and unknown faculty status info
-            if @auth_data.extra.raw_info.present?
+            raw_info = @auth_data.extra.raw_info
+            if raw_info.present?
               begin
-                account.faculty_status = @auth_data.extra.raw_info['faculty_status'] || :no_faculty_info
+                account.faculty_status = raw_info['faculty_status'] || :no_faculty_info
               rescue ArgumentError => ee
                 account.faculty_status = :no_faculty_info
               end
+
+              begin
+                account.role = raw_info['self_reported_role'] || :unknown_role
+              rescue ArgumentError => ee
+                account.role = :unknown_role
+              end
+
+              account.uuid = raw_info['uuid']
+
             end
           end
+
+          outputs[:account].save if outputs[:account].changed?
         rescue ActiveRecord::RecordNotUnique
           retry
         end

--- a/spec/controllers/openstax/accounts/forwards_params_spec.rb
+++ b/spec/controllers/openstax/accounts/forwards_params_spec.rb
@@ -29,24 +29,26 @@ describe "Forwards params", type: :request do
   end
 
   def test_forwards(key:, value:)
-    get '/forwards_params_route'
+    silence_omniauth do
+      get '/forwards_params_route'
 
-    expect(redirect_path).to eq "/accounts/login"
-    expect(redirect_query_hash).to include(key => value)
+      expect(redirect_path).to eq "/accounts/login"
+      expect(redirect_query_hash).to include(key => value)
 
-    with_stubbing(false) do
+      with_stubbing(false) do
+        get redirect_path_and_query
+      end
+
+      expect(redirect_path).to eq "/accounts/auth/openstax"
+      expect(redirect_query_hash).to include(key => value)
+
       get redirect_path_and_query
+
+      expect(redirect_path).to eq("/oauth/authorize")
+      expect(redirect_query_hash).to include(key => value)
+
+      # This last redirect was to Accounts, so we don't follow it
     end
-
-    expect(redirect_path).to eq "/accounts/auth/openstax"
-    expect(redirect_query_hash).to include(key => value)
-
-    get redirect_path_and_query
-
-    expect(redirect_path).to eq("/oauth/authorize")
-    expect(redirect_query_hash).to include(key => value)
-
-    # This last redirect was to Accounts, so we don't follow it
   end
 
   def redirect_path

--- a/spec/handlers/openstax/accounts/sessions_callback_spec.rb
+++ b/spec/handlers/openstax/accounts/sessions_callback_spec.rb
@@ -29,6 +29,52 @@ module OpenStax
         end
       end
 
+      context "uuid" do
+        it "sets the UUID on the account" do
+          result = described_class.handle(request: mock_omniauth_request(uuid: "howdy_ho"))
+          expect(result.outputs.account.uuid).to eq "howdy_ho"
+        end
+      end
+
+      context "role" do
+        it "sets the role on the account" do
+          result = described_class.handle(request: mock_omniauth_request(self_reported_role: "instructor"))
+          expect(result.outputs.account.role).to eq "instructor"
+        end
+
+        it "deals with unknown role (e.g. if Accounts update but this repo not)" do
+          result = described_class.handle(request: mock_omniauth_request(self_reported_role: "howdy_ho"))
+          expect(result.outputs.account).to be_unknown_role
+        end
+      end
+
+      context "user exists" do
+        it "updates the user's data" do
+          existing_account = FactoryGirl.create :openstax_accounts_account
+          result = described_class.handle(
+            request: mock_omniauth_request(
+              uid: existing_account.openstax_uid,
+              first_name: "1234",
+              last_name: "5678",
+              title: "900",
+              nickname: "191919",
+              faculty_status: "confirmed_faculty",
+              uuid: "yoyoma",
+              self_reported_role: "instructor")
+          )
+
+          account = result.outputs.account.reload
+          expect(account.id).to eq existing_account.id
+          expect(account.first_name).to eq "1234"
+          expect(account.last_name).to eq "5678"
+          expect(account.title).to eq "900"
+          expect(account.username).to eq "191919"
+          expect(account).to be_confirmed_faculty
+          expect(account.uuid).to eq "yoyoma"
+          expect(account).to be_instructor
+        end
+      end
+
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,17 +43,20 @@ RSpec.configure do |config|
 end
 
 
-def mock_omniauth_request(uid: nil, first_name: nil, last_name: nil, title: nil, nickname: nil, faculty_status: nil)
+def mock_omniauth_request(uid: nil, first_name: nil, last_name: nil, title: nil,
+                          nickname: nil, faculty_status: nil, uuid: nil, self_reported_role: nil)
   extra_hash = {
     'raw_info' => {
-      'faculty_status' => faculty_status
+      'faculty_status' => faculty_status,
+      'uuid' => uuid,
+      'self_reported_role' => self_reported_role
     }
   }
 
   OpenStruct.new(
     env: {
       'omniauth.auth' => OpenStruct.new({
-        uid: uid || SecureRandom.hex(4),
+        uid: uid || SecureRandom.random_number(10000000),
         provider: "openstax",
         info: OpenStruct.new({
           nickname: nickname || "",
@@ -86,4 +89,12 @@ def with_stubbing(value)
   ensure
     OpenStax::Accounts.configuration.enable_stubbing = original
   end
+end
+
+def silence_omniauth
+  previous_logger = OmniAuth.config.logger
+  OmniAuth.config.logger = Logger.new("/dev/null")
+  yield
+ensure
+  OmniAuth.config.logger = previous_logger
 end


### PR DESCRIPTION
* Previously accounts-rails didn't use the user profile JSON to update existing users, now it does.
* Sets role and uuid on login