### PR TITLE
Set role and UUID for stubs and find or create

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+
+
+7.6.0
+-----
+
+* Set `role` and `uuid` for stubbed accounts
+* Set `role` and `uuid` when find or create unclaimed accounts

--- a/app/handlers/openstax/accounts/dev/accounts_create.rb
+++ b/app/handlers/openstax/accounts/dev/accounts_create.rb
@@ -9,6 +9,7 @@ module OpenStax
         paramify :create do
           attribute :username, type: String
           validates :username, presence: true
+          attribute :role, type: String
         end
 
         uses_routine OpenStax::Accounts::Dev::CreateAccount,
@@ -23,10 +24,10 @@ module OpenStax
         end
 
         def handle
-          run(:create_account, create_params.as_hash(:username))
+          run(:create_account, create_params.as_hash(:username, :role))
         end
 
-      end 
+      end
     end
 
   end

--- a/app/representers/openstax/accounts/api/v1/unclaimed_account_representer.rb
+++ b/app/representers/openstax/accounts/api/v1/unclaimed_account_representer.rb
@@ -17,6 +17,13 @@ module OpenStax
                      required: true
                    }
 
+          property :uuid,
+                   type: String,
+                   schema_info: {
+                     description: "The unclaimed account's UUID",
+                     required: true
+                   }
+
         end
       end
     end

--- a/app/routines/openstax/accounts/dev/create_account.rb
+++ b/app/routines/openstax/accounts/dev/create_account.rb
@@ -23,6 +23,8 @@ module OpenStax
           account.openstax_uid = -SecureRandom.hex(4).to_i(16)/2
           account.access_token = SecureRandom.hex.to_s
           account.username = username
+          account.uuid = SecureRandom.uuid
+          account.role = inputs[:role] || :unknown_role
 
           account.save
 

--- a/app/routines/openstax/accounts/find_or_create_account.rb
+++ b/app/routines/openstax/accounts/find_or_create_account.rb
@@ -17,6 +17,7 @@ module OpenStax
           # We can only stub finding by username b/c accounts-rails doesn't persist emails
           id = Account.find_by(username: username).try!(:openstax_uid) ||
                -SecureRandom.hex(4).to_i(16)/2
+          uuid = SecureRandom.uuid
         else
           response = Api.find_or_create_account(
             email: email, username: username, password: password,
@@ -28,6 +29,7 @@ module OpenStax
           struct = OpenStruct.new
           Api::V1::UnclaimedAccountRepresenter.new(struct).from_json(response.body)
           id = struct.id
+          uuid = struct.uuid
         end
 
         account = Account.find_or_initialize_by(openstax_uid: id)
@@ -43,6 +45,8 @@ module OpenStax
           account.title = title
           account.salesforce_contact_id = salesforce_contact_id
           account.faculty_status = faculty_status || :no_faculty_info
+          account.role = role || :unknown_role
+          account.uuid = uuid
           account.save!
         end
 

--- a/app/views/openstax/accounts/dev/accounts/index.html.erb
+++ b/app/views/openstax/accounts/dev/accounts/index.html.erb
@@ -9,9 +9,10 @@
                    method: :post,
                    html: {class: 'form-inline'} do |f| %>
 
-    <%= f.label :username %>&nbsp;
+
     <div class="form-group">
-      <%= f.text_field :username %>&nbsp;
+      <%= f.text_field :username, placeholder: "Username" %>&nbsp;
+      <%= f.select :role, OpenStax::Accounts::Account.roles.keys.map{|rr| [rr, rr]} %>&nbsp;
       <%= f.submit 'Create', class: 'btn btn-primary' %>
     </div>
 

--- a/spec/cassettes/OpenStax_Accounts_FindOrCreateAccount/can_create_users.yml
+++ b/spec/cassettes/OpenStax_Accounts_FindOrCreateAccount/can_create_users.yml
@@ -5,14 +5,12 @@ http_interactions:
     uri: http://localhost:2999/oauth/token
     body:
       encoding: UTF-8
-      string: grant_type=client_credentials
+      string: client_id=6f3dbfdbb87bf28db1c8279f44c39ea3c3a702ae4303ebcb5a5d8067dc040f85&client_secret=a439ff2377713b3372f8044062f23ad1eb515237e1711cbe6f442c1bea935373&grant_type=client_credentials
     headers:
       User-Agent:
       - Faraday v0.9.2
       Content-Type:
       - application/x-www-form-urlencoded
-      Authorization:
-      - Basic c2VjcmV0OnNlY3JldA==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -22,6 +20,12 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
       Cache-Control:
       - no-store
       Pragma:
@@ -30,38 +34,36 @@ http_interactions:
       - application/json; charset=utf-8
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
-      X-Ua-Compatible:
-      - IE=Edge
       Etag:
-      - '"4d3718fd0478ef136de460e558d5c8d7"'
+      - W/"da2f9b92fc82c5fa07f64029a71cff95"
       X-Request-Id:
-      - 249cad60b7aebb41386944e6b96e58b9
+      - 26a0a272-9fcf-42c9-a702-357b46a5c070
       X-Runtime:
-      - '0.016859'
+      - '0.030377'
       Connection:
       - close
       Server:
       - thin
     body:
       encoding: UTF-8
-      string: '{"access_token":"62eff19592e9e0cfdf08b43d4829d47ad0d321f78ad6e81b37199db94c3d5531","token_type":"bearer","created_at":1462315169}'
+      string: '{"access_token":"c31fe09157c9801c88356a972d0e0c95aa13081cea77ae45f098b5dc7f614642","token_type":"bearer","created_at":1497844427}'
     http_version: 
-  recorded_at: Tue, 03 May 2016 22:39:29 GMT
+  recorded_at: Mon, 19 Jun 2017 03:53:47 GMT
 - request:
     method: post
     uri: http://localhost:2999/api/user/find-or-create
     body:
       encoding: UTF-8
-      string: '{"email":"alice@example.com","username":null,"password":null,"first_name":null,"last_name":null,"full_name":null}'
+      string: '{"email":"alice@example.com","username":null,"password":null,"first_name":null,"last_name":null,"full_name":null,"salesforce_contact_id":null,"faculty_status":null,"role":null}'
     headers:
       User-Agent:
       - Faraday v0.9.2
       Accept:
       - application/vnd.accounts.openstax.v1
-      Authorization:
-      - Bearer 62eff19592e9e0cfdf08b43d4829d47ad0d321f78ad6e81b37199db94c3d5531
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
+      Authorization:
+      - Bearer c31fe09157c9801c88356a972d0e0c95aa13081cea77ae45f098b5dc7f614642
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -69,42 +71,46 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 19 Jun 2017 03:53:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
-      X-Ua-Compatible:
-      - IE=Edge
       Etag:
-      - '"32010082256a713244a9f66180c4631e"'
+      - W/"c61c434670d5436a6af8a75c120f5bdf"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 7791a847ebc816bb146145e5f92fe7af
+      - 4d8fb993-d7ef-4820-9248-8c830caf1b78
       X-Runtime:
-      - '0.030350'
+      - '0.227730'
       Connection:
       - close
       Server:
       - thin
     body:
       encoding: UTF-8
-      string: '{"id":52}'
+      string: '{"id":18,"uuid":"8c5c819f-d9d9-46e7-98b9-d737fc0f13fe"}'
     http_version: 
-  recorded_at: Tue, 03 May 2016 22:39:29 GMT
+  recorded_at: Mon, 19 Jun 2017 03:53:47 GMT
 - request:
     method: post
     uri: http://localhost:2999/oauth/token
     body:
       encoding: UTF-8
-      string: grant_type=client_credentials
+      string: client_id=6f3dbfdbb87bf28db1c8279f44c39ea3c3a702ae4303ebcb5a5d8067dc040f85&client_secret=a439ff2377713b3372f8044062f23ad1eb515237e1711cbe6f442c1bea935373&grant_type=client_credentials
     headers:
       User-Agent:
       - Faraday v0.9.2
       Content-Type:
       - application/x-www-form-urlencoded
-      Authorization:
-      - Basic c2VjcmV0OnNlY3JldA==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -114,6 +120,12 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
       Cache-Control:
       - no-store
       Pragma:
@@ -122,38 +134,36 @@ http_interactions:
       - application/json; charset=utf-8
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
-      X-Ua-Compatible:
-      - IE=Edge
       Etag:
-      - '"db04ae46157ec6201ca409769f9016d8"'
+      - W/"c7a634c41cb04b393e0cd348d63efec1"
       X-Request-Id:
-      - b1535a57c791c79854f6c336af0bc4fd
+      - b977409f-0914-4eac-832e-3d406140ef24
       X-Runtime:
-      - '0.010447'
+      - '0.023528'
       Connection:
       - close
       Server:
       - thin
     body:
       encoding: UTF-8
-      string: '{"access_token":"8775df1803c483f2c200833d73be5a6a47ee5734c13954b608a61c6a32b77a87","token_type":"bearer","created_at":1462315169}'
+      string: '{"access_token":"1c4df98e8f1b07b4dd33aa81150262c829999aaf0564721c423f01c263c2114f","token_type":"bearer","created_at":1497844427}'
     http_version: 
-  recorded_at: Tue, 03 May 2016 22:39:29 GMT
+  recorded_at: Mon, 19 Jun 2017 03:53:47 GMT
 - request:
     method: post
     uri: http://localhost:2999/api/user/find-or-create
     body:
       encoding: UTF-8
-      string: '{"email":null,"username":"alice","password":null,"first_name":null,"last_name":null,"full_name":null}'
+      string: '{"email":null,"username":"alice","password":null,"first_name":null,"last_name":null,"full_name":null,"salesforce_contact_id":null,"faculty_status":null,"role":null}'
     headers:
       User-Agent:
       - Faraday v0.9.2
       Accept:
       - application/vnd.accounts.openstax.v1
-      Authorization:
-      - Bearer 8775df1803c483f2c200833d73be5a6a47ee5734c13954b608a61c6a32b77a87
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
+      Authorization:
+      - Bearer 1c4df98e8f1b07b4dd33aa81150262c829999aaf0564721c423f01c263c2114f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -161,42 +171,46 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 19 Jun 2017 03:53:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
-      X-Ua-Compatible:
-      - IE=Edge
       Etag:
-      - '"e773f5532f2567755653d537dac4a60b"'
+      - W/"a6c213351d9df66ee31997f7ed447fbc"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e5706745ca116b03fa6c1b69557a40f9
+      - ee7c0cba-d530-4a21-b94c-5adf7efb994a
       X-Runtime:
-      - '0.027753'
+      - '0.067316'
       Connection:
       - close
       Server:
       - thin
     body:
       encoding: UTF-8
-      string: '{"id":53}'
+      string: '{"id":19,"uuid":"c1ebaa86-b8ef-4100-9213-a16ca741d47f"}'
     http_version: 
-  recorded_at: Tue, 03 May 2016 22:39:29 GMT
+  recorded_at: Mon, 19 Jun 2017 03:53:47 GMT
 - request:
     method: post
     uri: http://localhost:2999/oauth/token
     body:
       encoding: UTF-8
-      string: grant_type=client_credentials
+      string: client_id=6f3dbfdbb87bf28db1c8279f44c39ea3c3a702ae4303ebcb5a5d8067dc040f85&client_secret=a439ff2377713b3372f8044062f23ad1eb515237e1711cbe6f442c1bea935373&grant_type=client_credentials
     headers:
       User-Agent:
       - Faraday v0.9.2
       Content-Type:
       - application/x-www-form-urlencoded
-      Authorization:
-      - Basic c2VjcmV0OnNlY3JldA==
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -206,6 +220,12 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
       Cache-Control:
       - no-store
       Pragma:
@@ -214,38 +234,36 @@ http_interactions:
       - application/json; charset=utf-8
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
-      X-Ua-Compatible:
-      - IE=Edge
       Etag:
-      - '"ce964e7db2a0f7f30e6ba0a48b4e2288"'
+      - W/"a0d885d8947b3be5da25673a937640fc"
       X-Request-Id:
-      - d5da0cb12baeca40f42dcaf8278cf410
+      - 21711558-b1df-4a12-b141-1e0a073f71db
       X-Runtime:
-      - '0.014209'
+      - '0.022856'
       Connection:
       - close
       Server:
       - thin
     body:
       encoding: UTF-8
-      string: '{"access_token":"b7c5ce6a934afb2274976c59a0be9f7302b65a013b213ca43068f257fb6e025b","token_type":"bearer","created_at":1462315169}'
+      string: '{"access_token":"21bb7c60df067e7354ec7e3b2e83d2d39831aece5938d20e8e68e6ea52ab59ff","token_type":"bearer","created_at":1497844427}'
     http_version: 
-  recorded_at: Tue, 03 May 2016 22:39:29 GMT
+  recorded_at: Mon, 19 Jun 2017 03:53:47 GMT
 - request:
     method: post
     uri: http://localhost:2999/api/user/find-or-create
     body:
       encoding: UTF-8
-      string: '{"email":null,"username":"alice2","password":"abcdefghijklmnop","first_name":null,"last_name":null,"full_name":null}'
+      string: '{"email":null,"username":"alice2","password":"abcdefghijklmnop","first_name":null,"last_name":null,"full_name":null,"salesforce_contact_id":null,"faculty_status":null,"role":null}'
     headers:
       User-Agent:
       - Faraday v0.9.2
       Accept:
       - application/vnd.accounts.openstax.v1
-      Authorization:
-      - Bearer b7c5ce6a934afb2274976c59a0be9f7302b65a013b213ca43068f257fb6e025b
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
+      Authorization:
+      - Bearer 21bb7c60df067e7354ec7e3b2e83d2d39831aece5938d20e8e68e6ea52ab59ff
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -253,27 +271,33 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 19 Jun 2017 03:53:48 GMT
       Content-Type:
       - application/json; charset=utf-8
       P3p:
       - CP="NOI ADM DEV PSAi COM NAV OUR OTRo STP IND DEM"
-      X-Ua-Compatible:
-      - IE=Edge
       Etag:
-      - '"113a43af89a575a4de9d701e79ea00b2"'
+      - W/"1574b45433f3e6117795d9e71a8a7fc9"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 203238eaa5500b54f6122aa9138b62f2
+      - 818cfe0a-9264-43c8-a73f-48cfbea35672
       X-Runtime:
-      - '0.034642'
+      - '0.142613'
       Connection:
       - close
       Server:
       - thin
     body:
       encoding: UTF-8
-      string: '{"id":54}'
+      string: '{"id":20,"uuid":"76c36a75-5b5a-4dbd-8800-5c1916c6f1f2"}'
     http_version: 
-  recorded_at: Tue, 03 May 2016 22:39:29 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Mon, 19 Jun 2017 03:53:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/routines/openstax/accounts/find_or_create_account_spec.rb
+++ b/spec/routines/openstax/accounts/find_or_create_account_spec.rb
@@ -15,8 +15,10 @@ module OpenStax
       end
 
       it 'can create users' do
-        account_1 = FindOrCreateAccount.call(email: 'alice@example.com').outputs.account
+        account_1 = FindOrCreateAccount.call(email: 'alice@example.com', role: 'instructor').outputs.account
         expect(account_1).to be_persisted
+        expect(account_1.uuid).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i)
+        expect(account_1.role).to eq 'instructor'
 
         account_2 = FindOrCreateAccount.call(username: 'alice').outputs.account
         expect(account_2).to be_persisted


### PR DESCRIPTION
Now when accounts are created when OX Accounts is stubbed, the `uuid` and `role` are set.  When unclaimed users are created (via "find or create" API calls, the role and UUID is set appropriately).