### PR TITLE
add optional signed login url

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ OpenStax::Accounts::Engine.routes.draw do
     get 'failure', :path => 'auth/failure' # Authentication failure
 
     get 'login', :action => :new # Redirects to /auth/openstax or stub
+    get 'signed_login', :action => :new, :sign => 1 # signs query parameters
+
     match 'logout', :action => :destroy, # Redirects to logout path or stub
                     :via => OpenStax::Accounts.configuration.logout_via
     get 'profile', :action => :profile # Redirects to profile path or stub

--- a/lib/openstax/accounts/query_helper.rb
+++ b/lib/openstax/accounts/query_helper.rb
@@ -1,0 +1,64 @@
+module OpenStax
+  module Accounts
+    module QueryHelper
+      # Borrowed from https://github.com/oauth-xx/oauth-ruby/blob/e397b3e2f540faaebd7912aeb2768835d151f795/lib/oauth/helper.rb
+      # so we can call `normalize` on some params without adding dependence on full oauth gem
+
+      RESERVED_CHARACTERS = /[^a-zA-Z0-9\-\.\_\~]/
+
+      extend self
+
+      # Escape +value+ by URL encoding all non-reserved character.
+      def escape(value)
+        _escape(value.to_s.to_str)
+      rescue ArgumentError
+        _escape(value.to_s.to_str.force_encoding(Encoding::UTF_8))
+      end
+
+      def _escape(string)
+        URI.escape(string, RESERVED_CHARACTERS)
+      end
+
+      # Normalize a +Hash+ of parameter values. Parameters are sorted by name, using lexicographical
+      # byte value ordering. If two or more parameters share the same name, they are sorted by their value.
+      # Parameters are concatenated in their sorted order into a single string. For each parameter, the name
+      # is separated from the corresponding value by an "=" character, even if the value is empty. Each
+      # name-value pair is separated by an "&" character.
+      def normalize(params)
+        params.sort.map do |k, values|
+          if values.is_a?(Array)
+            # make sure the array has an element so we don't lose the key
+            values << nil if values.empty?
+            # multiple values were provided for a single key
+            values.sort.collect do |v|
+              [escape(k),escape(v)] * "="
+            end
+          elsif values.is_a?(Hash)
+            normalize_nested_query(values, k)
+          else
+            [escape(k),escape(values)] * "="
+          end
+        end * "&"
+      end
+
+      #Returns a string representation of the Hash like in URL query string
+      # build_nested_query({:level_1 => {:level_2 => ['value_1','value_2']}}, 'prefix'))
+      #   #=> ["prefix%5Blevel_1%5D%5Blevel_2%5D%5B%5D=value_1", "prefix%5Blevel_1%5D%5Blevel_2%5D%5B%5D=value_2"]
+      def normalize_nested_query(value, prefix = nil)
+        case value
+        when Array
+          value.map do |v|
+            normalize_nested_query(v, "#{prefix}[]")
+          end.flatten.sort
+        when Hash
+          value.map do |k, v|
+            normalize_nested_query(v, prefix ? "#{prefix}[#{k}]" : k)
+          end.flatten.sort
+        else
+          [escape(prefix), escape(value)] * "="
+        end
+      end
+
+    end
+  end
+end

--- a/lib/openstax_accounts.rb
+++ b/lib/openstax_accounts.rb
@@ -4,6 +4,7 @@ require 'openstax_utilities'
 require 'uri'
 require 'omniauth/strategies/openstax'
 require 'openstax/accounts/api'
+require 'openstax/accounts/query_helper'
 require 'openstax/accounts/configuration'
 require 'openstax/accounts/current_user_manager'
 require 'openstax/accounts/default_account_user_mapper'
@@ -27,7 +28,7 @@ module OpenStax
       #     ...
       #   end
       #
-      
+
       def configure
         yield configuration
       end

--- a/spec/controllers/openstax/accounts/forwards_params_spec.rb
+++ b/spec/controllers/openstax/accounts/forwards_params_spec.rb
@@ -50,21 +50,4 @@ describe "Forwards params", type: :request do
       # This last redirect was to Accounts, so we don't follow it
     end
   end
-
-  def redirect_path
-    redirect_uri.path
-  end
-
-  def redirect_path_and_query
-    "#{redirect_uri.path}?#{redirect_uri.query}"
-  end
-
-  def redirect_query_hash
-    Rack::Utils.parse_nested_query(redirect_uri.query).symbolize_keys
-  end
-
-  def redirect_uri
-    expect(response.code).to eq "302"
-    uri = URI.parse(response.headers["Location"])
-  end
 end

--- a/spec/controllers/openstax/accounts/signed_login_spec.rb
+++ b/spec/controllers/openstax/accounts/signed_login_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "Signed login", type: :request do
+
+  context 'without stubbing' do
+    around(:each) {|example| with_stubbing(false){ example.run}}
+
+    it 'signs the login params' do
+      get '/accounts/signed_login?go=somewhere'
+      expect(redirect_query_hash[:signature]).to be_a String
+      expect(redirect_query_hash[:timestamp]).to be_a String
+      expect(redirect_query_hash[:go]).to eq "somewhere"
+      expect(redirect_path).to eq "/accounts/auth/openstax"
+
+      # Pretend like we are receiving the signature and check that it is good
+      params = redirect_query_hash
+      incoming_signature = params.delete(:signature)
+      normalized_params_string = OpenStax::Accounts::QueryHelper.normalize(params)
+      computed_signature = OpenSSL::HMAC.hexdigest(
+                             'sha1',
+                             OpenStax::Accounts.configuration.openstax_application_secret,
+                             normalized_params_string
+                            )
+      expect(incoming_signature).to eq computed_signature
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,3 +98,20 @@ def silence_omniauth
 ensure
   OmniAuth.config.logger = previous_logger
 end
+
+def redirect_path
+  redirect_uri.path
+end
+
+def redirect_path_and_query
+  "#{redirect_uri.path}?#{redirect_uri.query}"
+end
+
+def redirect_query_hash
+  Rack::Utils.parse_nested_query(redirect_uri.query).symbolize_keys
+end
+
+def redirect_uri
+  expect(response.code).to eq "302"
+  uri = URI.parse(response.headers["Location"])
+end


### PR DESCRIPTION
Client apps can now redirect to `openstax_accounts.signed_login_url` to get the redirect's parameters signed with the app's secret key (a la OAuth 1.0).

The signed parameters will get a timestamp added to them.