### PR TITLE
Set salesforce_contact_id on account creation; Update role on account sync

### DIFF
--- a/app/handlers/openstax/accounts/sessions_callback.rb
+++ b/app/handlers/openstax/accounts/sessions_callback.rb
@@ -1,8 +1,6 @@
 module OpenStax
   module Accounts
-
     class SessionsCallback
-
       lev_handler
 
       protected
@@ -12,59 +10,41 @@ module OpenStax
       end
 
       def authorized?
-        @auth_data.provider == "openstax"
+        @auth_data.provider == 'openstax'
       end
 
       def handle
-        # Don't worry if the account is logged in or not beforehand.
-        # Just assume that they aren't.
+        # Don't worry if the account is logged in or not beforehand. Just assume that they aren't.
 
-        # http://apidock.com/rails/v4.0.2/ActiveRecord/Relation/find_or_create_by
+        # tap is used because we want the block to always run (not just when initializing)
         begin
-          outputs[:account] = Account.find_or_initialize_by(openstax_uid: @auth_data.uid).tap do |account|
-            account.username     = @auth_data.info.nickname
-            account.first_name   = @auth_data.info.first_name
-            account.last_name    = @auth_data.info.last_name
-            account.full_name    = @auth_data.info.name
-            account.title        = @auth_data.info.title
+          outputs.account = Account.find_or_initialize_by(
+            openstax_uid: @auth_data.uid
+          ).tap do |account|
             account.access_token = @auth_data.credentials.token
 
-            # Gracefully handle absent and unknown faculty status info
             raw_info = @auth_data.extra.raw_info
-            if raw_info.present?
+            OpenStax::Accounts::Account::SYNC_ATTRIBUTES.each do |attribute|
               begin
-                account.faculty_status = raw_info['faculty_status'] || :no_faculty_info
-              rescue ArgumentError => ee
-                account.faculty_status = :no_faculty_info
+                account.send "#{attribute}=", raw_info[attribute]
+              rescue ArgumentError
+                # Ignore errors, for example if enum values are invalid
               end
-
-              begin
-                account.role = raw_info['self_reported_role'] || :unknown_role
-              rescue ArgumentError => ee
-                account.role = :unknown_role
-              end
-
-              begin
-                account.school_type = raw_info['school_type'] || :unknown_school_type
-              rescue ArgumentError => ee
-                account.school_type = :unknown_school_type
-              end
-
-              account.uuid = raw_info['uuid']
-              account.support_identifier = raw_info['support_identifier']
-              account.is_test = raw_info['is_test']
             end
+
+            # Gracefully handle absent and unknown enum values
+            account.faculty_status ||= :no_faculty_info
+            account.role ||= :unknown_role
+            account.school_type ||= :unknown_school_type
           end
 
-          outputs[:account].save if outputs[:account].changed?
+          outputs.account.save if outputs.account.changed?
         rescue ActiveRecord::RecordNotUnique
           retry
         end
 
-        transfer_errors_from(outputs[:account], {type: :verbatim})
+        transfer_errors_from(outputs.account, type: :verbatim)
       end
-
     end
-
   end
 end

--- a/app/models/openstax/accounts/account.rb
+++ b/app/models/openstax/accounts/account.rb
@@ -43,7 +43,8 @@ module OpenStax::Accounts
       :librarian,
       :designer,
       :other,
-      :adjunct
+      :adjunct,
+      :homeschool
     ]
     enum school_type: [:unknown_school_type, :other_school_type, :college]
 

--- a/app/models/openstax/accounts/account.rb
+++ b/app/models/openstax/accounts/account.rb
@@ -3,6 +3,20 @@ module OpenStax::Accounts
 
     USERNAME_DISCARDED_CHAR_REGEX = /[^A-Za-z\d_]/
     USERNAME_MAX_LENGTH = 50
+    SYNC_ATTRIBUTES = [
+      :username,
+      :first_name,
+      :last_name,
+      :full_name,
+      :title,
+      :self_reported_role,
+      :faculty_status,
+      :school_type,
+      :salesforce_contact_id,
+      :uuid,
+      :support_identifier,
+      :is_test
+    ]
 
     attr_accessor :syncing
 
@@ -60,6 +74,14 @@ module OpenStax::Accounts
 
     def valid_openstax_uid?
       !openstax_uid.nil? && openstax_uid > 0
+    end
+
+    def self_reported_role
+      role
+    end
+
+    def self_reported_role=(role)
+      self.role = role
     end
 
     protected

--- a/app/routines/openstax/accounts/sync_accounts.rb
+++ b/app/routines/openstax/accounts/sync_accounts.rb
@@ -7,11 +7,6 @@ module OpenStax
 
     class SyncAccounts
 
-      SYNC_ATTRIBUTES = [
-        'username', 'first_name', 'last_name', 'full_name', 'title', 'role', 'faculty_status',
-        'school_type', 'salesforce_contact_id', 'uuid', 'support_identifier', 'is_test'
-      ]
-
       lev_routine transaction: :no_transaction
 
       protected
@@ -37,7 +32,7 @@ module OpenStax
           account.syncing = true
 
           if account != app_account.account
-            SYNC_ATTRIBUTES.each do |attribute|
+            OpenStax::Accounts::Account::SYNC_ATTRIBUTES.each do |attribute|
               account.send("#{attribute}=", app_account.account.send(attribute))
             end
           end

--- a/lib/omniauth/strategies/openstax.rb
+++ b/lib/omniauth/strategies/openstax.rb
@@ -7,38 +7,21 @@ module OmniAuth
       option :name, "openstax"
 
       option :client_options, {
-        :site => "http://accounts.openstax.org",
-        :authorize_url => "/oauth/authorize"
+        site: "http://accounts.openstax.org",
+        authorize_url: "/oauth/authorize"
       }
 
-      uid { raw_info["id"] }
+      uid { raw_info[:id] }
 
       info do
-        username = raw_info["username"]
-        title = raw_info["title"]
-        first_name = raw_info["first_name"]
-        last_name = raw_info["last_name"]
-        full_name = raw_info["full_name"] || "#{first_name} #{last_name}"
-        full_name = username if full_name.blank?
-
         # Changed to conform to the omniauth schema
-        {
-          name: full_name,
-          nickname: username,
-          first_name: first_name,
-          last_name: last_name,
-          title: title
-        }
+        raw_info.slice(:name, :first_name, :last_name, :title).merge(nickname: raw_info[:username])
       end
 
-      extra do
-        {
-          'raw_info' => raw_info
-        }
-      end
+      extra { { raw_info: raw_info } }
 
       def raw_info
-        @raw_info ||= access_token.get('/api/user.json').parsed
+        @raw_info ||= access_token.get('/api/user.json').parsed.symbolize_keys
       end
 
     end

--- a/spec/dummy/app/models/anonymous_user.rb
+++ b/spec/dummy/app/models/anonymous_user.rb
@@ -23,7 +23,7 @@ class AnonymousUser
     nil
   end
 
-  def authentications 
+  def authentications
     []
   end
 
@@ -38,11 +38,10 @@ class AnonymousUser
   end
 
   def full_name
-    "Anonymous User"
+    'Anonymous User'
   end
 
   def casual_name
     full_name
   end
-
 end

--- a/spec/dummy/app/models/ownership.rb
+++ b/spec/dummy/app/models/ownership.rb
@@ -1,7 +1,5 @@
 class Ownership < ActiveRecord::Base
-
   belongs_to :owner, polymorphic: true
 
   validates :owner, presence: true
-
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,13 +1,9 @@
 class User < ActiveRecord::Base
-
-  belongs_to :account, 
-             class_name: "OpenStax::Accounts::Account"
+  belongs_to :account, class_name: 'OpenStax::Accounts::Account'
   has_many :groups_as_member, through: :account
-  has_many_through_groups :groups_as_member, :ownerships,
-                          as: :owner, dependent: :destroy
+  has_many_through_groups :groups_as_member, :ownerships, as: :owner, dependent: :destroy
 
-  delegate :username, :first_name, :last_name, :full_name, :title,
-           :name, :casual_name, to: :account
+  delegate :username, :first_name, :last_name, :full_name, :title, :name, :casual_name, to: :account
 
   def is_anonymous?
     false
@@ -16,14 +12,10 @@ class User < ActiveRecord::Base
   # OpenStax Accounts "account_user_mapper" methods
 
   def self.account_to_user(acc)
-    acc.is_anonymous? ? \
-      AnonymousUser.instance : \
-      User.where(:account_id => acc.id).first
+    acc.is_anonymous? ? AnonymousUser.instance : where(account_id: acc.id).first
   end
 
   def self.user_to_account(user)
-    user.is_anonymous? ? \
-      AnonymousAccount.instance : \
-      user.account
+    user.is_anonymous? ? AnonymousAccount.instance : user.account
   end
 end

--- a/spec/handlers/openstax/accounts/sessions_callback_spec.rb
+++ b/spec/handlers/openstax/accounts/sessions_callback_spec.rb
@@ -2,13 +2,10 @@ require 'spec_helper'
 
 module OpenStax
   module Accounts
-
     RSpec.describe SessionsCallback do
-
-      it "deals with null faculty_status" do
+      it "deals with null username" do
         with_stubbing(false) do
           request = mock_omniauth_request
-          remove_nickname!(request)
           result = described_class.handle(request: request)
           expect(result.outputs.account).to be_valid
           expect(result.outputs.account).to be_persisted
@@ -43,8 +40,7 @@ module OpenStax
         end
 
         it "defaults to no_faculty_info if faculty status is not present" do
-          request = mock_omniauth_request()
-          remove_faculty_status!(request)
+          request = mock_omniauth_request(faculty_status: nil)
           result = described_class.handle(request: request)
           expect(result.outputs.account).to be_no_faculty_info
         end
@@ -82,6 +78,16 @@ module OpenStax
         end
       end
 
+      context "salesforce_contact_id" do
+        it "sets the salesforce_contact_id on the account" do
+          sf_contact_id = 'SomeSfId'
+          result = described_class.handle(
+            request: mock_omniauth_request(salesforce_contact_id: sf_contact_id)
+          )
+          expect(result.outputs.account.salesforce_contact_id).to eq sf_contact_id
+        end
+      end
+
       context "user exists" do
         it "updates the user's data" do
           existing_account = FactoryBot.create :openstax_accounts_account
@@ -89,11 +95,11 @@ module OpenStax
           support_identifier = "cs_#{SecureRandom.hex(4)}"
           result = described_class.handle(
             request: mock_omniauth_request(
-              uid: existing_account.openstax_uid,
+              id: existing_account.openstax_uid,
               first_name: "1234",
               last_name: "5678",
               title: "900",
-              nickname: "191919",
+              username: "191919",
               faculty_status: "confirmed_faculty",
               uuid: uuid,
               support_identifier: support_identifier,
@@ -112,8 +118,6 @@ module OpenStax
           expect(account).to be_instructor
         end
       end
-
     end
-
   end
 end


### PR DESCRIPTION
- Set salesforce_contact_id on account creation - fixes bug where Tutor was not sending data to SF about actions users did in the first minute after initial login
- Fix Account syncing so role (self_reported_role) can be updated