### PR TITLE
Make accounts-rails smaller

### DIFF
--- a/accounts-rails.gemspec
+++ b/accounts-rails.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "Rails common code and bindings for the 'accounts' API"
   s.description = "This gem allows Rails apps to easily access the API's and login infrastructure of OpenStax Accounts."
 
-  s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*"] +
-            ["MIT-LICENSE", "Rakefile", "README.md"]
-  s.test_files = Dir["spec/**/*"]
+  s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*"] + ["MIT-LICENSE", "README.md"]
 
   s.add_dependency "rails"
   s.add_dependency "omniauth"

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -2,17 +2,17 @@ namespace :openstax do
   namespace :accounts do
     namespace :sync do
       desc "Sync Accounts with OpenStax Accounts"
-      task :accounts => :environment do
+      task accounts: :environment do
         OpenStax::Accounts::SyncAccounts.call
       end
 
       desc "Sync Groups with OpenStax Accounts"
-      task :groups => :environment do
+      task groups: :environment do
         OpenStax::Accounts::SyncGroups.call
       end
 
       desc "Sync Accounts and Groups with OpenStax Accounts"
-      task :all => [:accounts, :groups]
+      task all: [:accounts, :groups]
     end
   end
 end


### PR DESCRIPTION
The `gem test` command was removed long ago.
Including test_files in the gem only makes the gem bigger... especially because the test log files are included!
Those can also contain sensitive information (probably not though).

The gem's `Rakefile` is not necessary for the gem (engine) tasks to work, as far as I can tell.
When you run `rake` in an app that installs the gem, the app's Rakefile is used and Rails automatically adds the engine's tasks.