### PR TITLE
Allow setting is_test during unclaimed user creation

### DIFF
--- a/app/representers/openstax/accounts/api/v1/unclaimed_account_representer.rb
+++ b/app/representers/openstax/accounts/api/v1/unclaimed_account_representer.rb
@@ -4,7 +4,7 @@ module OpenStax
       module V1
         class UnclaimedAccountRepresenter < Roar::Decorator
 
-          # This representer is used to communicate with Accounts
+          # This representer is used to read from Accounts
           # and so must allow read/write on all properties
           # Do not use it in create/update APIs!
 
@@ -28,12 +28,6 @@ module OpenStax
                    type: String,
                    schema_info: {
                      description: "The unclaimed account's support_identifier"
-                   }
-
-          property :is_test,
-                   type: :boolean,
-                   schema_info: {
-                     description: "Whether or not this is a test account"
                    }
 
         end

--- a/app/routines/openstax/accounts/find_or_create_account.rb
+++ b/app/routines/openstax/accounts/find_or_create_account.rb
@@ -6,12 +6,13 @@ module OpenStax
 
       protected
 
-      def exec(email: nil, username: nil, password: nil,
-               first_name: nil, last_name: nil, full_name: nil, title: nil,
-               salesforce_contact_id: nil, faculty_status: nil, role: nil, school_type: nil)
-        raise ArgumentError,
-              'You must specify either an email address or a username (and an optional password)' \
-                if email.nil? && username.nil?
+      def exec(email: nil, username: nil, password: nil, first_name: nil, last_name: nil,
+               full_name: nil, title: nil, salesforce_contact_id: nil, faculty_status: nil,
+               role: nil, school_type: nil, is_test: nil)
+        raise(
+          ArgumentError,
+          'You must specify either an email address or a username (and an optional password)'
+        ) if email.nil? && username.nil?
 
         if OpenStax::Accounts.configuration.enable_stubbing
           # We can only stub finding by username b/c accounts-rails doesn't persist emails
@@ -24,7 +25,7 @@ module OpenStax
             email: email, username: username, password: password,
             first_name: first_name, last_name: last_name, full_name: full_name,
             salesforce_contact_id: salesforce_contact_id, faculty_status: faculty_status,
-            role: role, school_type: school_type)
+            role: role, school_type: school_type, is_test: is_test)
           fatal_error(code: :invalid_inputs) unless (200..202).include?(response.status)
 
           struct = OpenStruct.new
@@ -32,7 +33,6 @@ module OpenStax
           id = struct.id
           uuid = struct.uuid
           support_identifier = struct.support_identifier
-          is_test = struct.is_test
         end
 
         account = Account.find_or_initialize_by(openstax_uid: id)
@@ -57,7 +57,7 @@ module OpenStax
         end
 
         transfer_errors_from(account, {type: :verbatim}, true)
-        outputs[:account] = account
+        outputs.account = account
       end
 
     end

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = "8.0.1"
+    VERSION = "8.1.0"
   end
 end

--- a/spec/lib/openstax/accounts/api_spec.rb
+++ b/spec/lib/openstax/accounts/api_spec.rb
@@ -16,7 +16,7 @@ module OpenStax
 
       it 'makes api requests' do
         reset(::Api::DummyController)
-        Api.request(:post, 'dummy', :params => {:test => true})
+        Api.request(:post, 'dummy', params: { test: true })
         expect(::Api::DummyController.last_action).to eq :dummy
         expect(::Api::DummyController.last_params).to include 'test' => 'true'
       end
@@ -28,30 +28,30 @@ module OpenStax
         it 'makes api call to users index' do
           Api.search_accounts('something')
           expect(::Api::UsersController.last_action).to eq :index
-          expect(::Api::UsersController.last_params).to include :q => 'something'
+          expect(::Api::UsersController.last_params).to include q: 'something'
         end
 
         it 'makes api call to user update' do
           Api.update_account(account)
           expect(::Api::UsersController.last_action).to eq :update
-          expect(::Api::UsersController.last_json).to include(
-            account.attributes.slice('username', 'first_name',
-              'last_name', 'full_name', 'title'))
-        end
-
-        it 'makes api call to (temp) user create by email' do
-          Api.find_or_create_account(email: 'dummy@dum.my')
-          expect(::Api::UsersController.last_action).to eq :create
-          expect(::Api::UsersController.last_json).to(
-            include('email' => 'dummy@dum.my')
+          expect(::Api::UsersController.last_json).to include account.attributes.slice(
+            'username', 'first_name', 'last_name', 'full_name', 'title'
           )
         end
 
-        it 'makes api call to (temp) user create by username' do
-          Api.find_or_create_account(username: 'dummy')
+        it 'makes api call to unclaimed user create by email' do
+          Api.find_or_create_account(email: 'dummy@dum.my', is_test: true)
           expect(::Api::UsersController.last_action).to eq :create
           expect(::Api::UsersController.last_json).to(
-            include('username' => 'dummy')
+            include('email' => 'dummy@dum.my', 'is_test' => true)
+          )
+        end
+
+        it 'makes api call to unclaimed user create by username' do
+          Api.find_or_create_account(username: 'dummy', is_test: false)
+          expect(::Api::UsersController.last_action).to eq :create
+          expect(::Api::UsersController.last_json).to(
+            include('username' => 'dummy', 'is_test' => false)
           )
         end
       end

--- a/spec/routines/openstax/accounts/find_or_create_account_spec.rb
+++ b/spec/routines/openstax/accounts/find_or_create_account_spec.rb
@@ -45,11 +45,12 @@ module OpenStax
             }\",\"support_identifier\":\"cs_#{SecureRandom.hex(4)}\"}"
           )
         )
+        is_test = [true, false].sample
         expect(OpenStax::Accounts::Api).to receive(:find_or_create_account).with(
           email: 'bob@example.com', username: nil, password: nil,
           first_name: 'Bob', last_name: 'Smith', full_name: 'Bob Smith',
           salesforce_contact_id: 'b0b', faculty_status: :rejected_faculty,
-          role: :instructor, school_type: :college
+          role: :instructor, school_type: :college, is_test: is_test
         ).and_return(find_or_create_account_response)
 
         described_class.call(
@@ -60,7 +61,8 @@ module OpenStax
           salesforce_contact_id: 'b0b',
           faculty_status: :rejected_faculty,
           role: :instructor,
-          school_type: :college
+          school_type: :college,
+          is_test: is_test
         )
       end
 


### PR DESCRIPTION
Necessary so users created by calls to the demo API in Tutor come marked as test users

Requires: https://github.com/openstax/accounts/pull/679
Required for: https://github.com/openstax/tutor-server/pull/1881