### PR TITLE
Fix potential fatal error if the auth/openstax routes ends up going to Rails

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ OpenStax::Accounts::Engine.routes.draw do
 
   # Shortcut to OmniAuth route that redirects to the Accounts server
   # This is provided by OmniAuth and is not in the SessionsController
-  get '/auth/openstax', as: 'openstax_login'
+  get '/auth/openstax', to: ->(env) { [ 404, {}, [ '' ] ] }, as: 'openstax_login'
 
   if OpenStax::Accounts.configuration.enable_stubbing?
     # User profile route

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = '9.0.1'
+    VERSION = '9.0.2'
   end
 end


### PR DESCRIPTION
There is no AuthController, so this route would just cause a fatal error (even though it should have been caught by OmniAuth...)
Render a 404 page instead.