### PR TITLE
set login params using sytax for strong parameters

### DIFF
--- a/accounts-rails.gemspec
+++ b/accounts-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "spec/factories/**/*"] + ["MIT-LICENSE", "README.md"]
 
-  s.add_dependency "rails", '< 6.0'
+  s.add_dependency "rails", '> 5.0'
   s.add_dependency "omniauth"
   s.add_dependency "omniauth-oauth2"
   s.add_dependency "oauth2"

--- a/app/controllers/openstax/accounts/sessions_controller.rb
+++ b/app/controllers/openstax/accounts/sessions_controller.rb
@@ -10,8 +10,7 @@ module OpenStax
         if configuration.enable_stubbing?
           redirect_to dev_accounts_path
         else
-          forwardable_params =
-            params.permit(*configuration.forwardable_login_param_keys.map(&:to_s)).to_h
+          forwardable_params = params.permit(*configuration.forwardable_login_params).to_h
           redirect_to openstax_login_path(forwardable_params)
         end
       end

--- a/lib/openstax/accounts/configuration.rb
+++ b/lib/openstax/accounts/configuration.rb
@@ -60,9 +60,9 @@ module OpenStax
       # to the default Accounts logout URL.
       attr_writer :logout_redirect_url
 
-      # forwardable_login_param_keys
+      # forwardable_login_params
       # Which params are forwarded on the accounts login path
-      attr_accessor :forwardable_login_param_keys
+      attr_accessor :forwardable_login_params
 
       # max_user_updates_per_request
       # When the user profile sync operation is called, this parameter will limit
@@ -119,10 +119,10 @@ module OpenStax
         @max_search_items = 10
         @logout_redirect_url = nil
         @return_to_url_approver = nil
-        @forwardable_login_param_keys = [
+        @forwardable_login_params = [
           :signup_at,
           :go,
-          :sp          # "signed payload"; "sp" for short to keep nested parameter names short
+          sp: {} # "signed payload"; "sp" to keep nested parameter names short.
         ]
         @max_user_updates_per_request = 250
         @sso_cookie_name = 'ox'

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = '9.0.2'
+    VERSION = '9.1.0'
   end
 end

--- a/spec/controllers/openstax/accounts/forwards_params_spec.rb
+++ b/spec/controllers/openstax/accounts/forwards_params_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Forwards params", type: :request do
     def set_login_param
       login_params[:signup_at] = "foo"
       login_params[:go] = "bar"
-      login_params[:sp] = "blah"
+      login_params[:sp] = { 'test' => '42' }
     end
   end
 
@@ -29,8 +29,8 @@ RSpec.describe "Forwards params", type: :request do
     test_forwards(key: :go, value: "bar")
   end
 
-  it "should forward go" do
-    test_forwards(key: :sp, value: "blah")
+  it "should forward sp" do
+    test_forwards(key: :sp, value: { 'test' => '42' })
   end
 
   def test_forwards(key:, value:)

--- a/spec/controllers/openstax/accounts/sessions_controller_spec.rb
+++ b/spec/controllers/openstax/accounts/sessions_controller_spec.rb
@@ -67,5 +67,13 @@ module OpenStax::Accounts
 
       get :new, params: { return_to: 'http://jimmy' }
     end
+
+    it 'should include sp param hash when redirecting' do
+      allow(OpenStax::Accounts.configuration).to receive(:enable_stubbing?) {false}
+      params = { sp: { foo: 'bar', test: 'true' } }
+      get :new, params: params
+      expect(response).to redirect_to(controller.openstax_login_path(params))
+    end
+
   end
 end


### PR DESCRIPTION
Nested params need to be permitted using hash syntax, which can't be given as just keys

This was causing the "sp" param to not be passed onto accounts

https://guides.rubyonrails.org/action_controller_overview.html#nested-parameters