### PR TITLE
Force SSL for the redirect_uri in prod

### DIFF
--- a/lib/omniauth/strategies/openstax.rb
+++ b/lib/omniauth/strategies/openstax.rb
@@ -24,6 +24,13 @@ module OmniAuth
         @raw_info ||= access_token.get('/api/user.json').parsed.symbolize_keys
       end
 
+      protected
+
+      def ssl?
+        return true if Rails.env.production?
+
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
CloudFront uses a CloudFront-Forwarded-Proto header that Omniauth does not recognize by default. We could check that header but instead we know production should always have SSL on so we do that instead.