### PR TITLE
Explicitly require openstax_api

### DIFF
--- a/app/representers/openstax/accounts/api/v1/account_search_representer.rb
+++ b/app/representers/openstax/accounts/api/v1/account_search_representer.rb
@@ -1,3 +1,5 @@
+require 'openstax_api'
+
 module OpenStax
   module Accounts
     module Api

--- a/lib/openstax/accounts/version.rb
+++ b/lib/openstax/accounts/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module Accounts
-    VERSION = '9.6.0'
+    VERSION = '9.6.1'
   end
 end


### PR DESCRIPTION
Otherwise the app may crash when trying to load the AccountSearchRepresenter